### PR TITLE
Increase granularity of machine names

### DIFF
--- a/site/profile/templates/provisioning/bootstrap.sh.erb
+++ b/site/profile/templates/provisioning/bootstrap.sh.erb
@@ -60,7 +60,7 @@ else
 fi
 
 ARRAY=(${EMAIL//@/ })
-DEFAULT="${ARRAY[0]}-$(date +%Y-%m-%d)"
+DEFAULT="${ARRAY[0]}-$(date +%Y-%m-%d-%H%M)"
 
 if [[ ! -v NONINTERACTIVE ]]; then
     echo -n "What would you like to call this node [${DEFAULT}]? "


### PR DESCRIPTION
This will allow machines to be built at a rate of one per minute by default. You can always create them faster via the interactive question, or by using the `-n` option.