### PR TITLE
Remove directions to send email

### DIFF
--- a/site/profile/files/fragments/docs.html
+++ b/site/profile/files/fragments/docs.html
@@ -78,8 +78,7 @@
       </li>
       <li><h4>What if I can't accept a self-signed certificate?</h4>
         <div class="answer">
-          <p>Please email <a href="mailto:eduteam@puppet.com">eduteam@puppet.com</a> and
-            let us know. We may be able to help you.</p>
+          <p>Please let us know in the feedback form at the end of the tests. We may be able to help you.</p>
         </div>
       </li>
       <li><h4>What can I do to mitigate a slow network?</h4>


### PR DESCRIPTION
I had talked to @binford2k about this on HipChat. We now have a process where the person running the tests can file a ticket. So having them also send an email is superfluous.