### PR TITLE
Increase PuppetDB memory to 768m

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,3 +1,6 @@
 ---
 puppet_enterprise::profile::console::proxy::http_redirect::enable_http_redirect: false
 puppet_enterprise::profile::console::console_ssl_listen_port: 442
+puppet_enterprise::profile::puppetdb::java_args:
+    Xmx: '768m'
+    Xms: '768m'


### PR DESCRIPTION
Prior to this commit the complexity of the catalogs was causing puppetdb to
crash every few minutes and cause build failures. This commit sets a new memory
allocation to a reasonable level.