### PR TITLE
Resolve the 30m facter hang when running on Virtualbox

### DIFF
--- a/site/profile/templates/provisioning/bootstrap.sh.erb
+++ b/site/profile/templates/provisioning/bootstrap.sh.erb
@@ -103,6 +103,9 @@ fi
 ############# now start doing stuffs! #################
 if [ -f /etc/redhat-release ]; then
   yum install -y rubygems ntpdate
+  
+  # work around https://tickets.puppetlabs.com/browse/FACT-1289 which was causing terrible facter hangs
+  yum remove -y virt-what
 elif [ -f /etc/debian_version ]; then
   echo "The Debian platform is support best-effort only."
   echo "       Press [enter] to continue."


### PR DESCRIPTION
When trying to bootstrap on a virtualbox machine, such as with Vagrant like we suggest, this was causing 30m facter hangs as each ec2 fact slowly timed out. Removing virt-what changes the fact resolution, and causes it to resolve accurately.